### PR TITLE
Correct Romanian label typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,7 +474,7 @@
             {
                 id: 'raspuns-urari', title: 'Răspuns Urări 💬', promptName: "Răspuns la Urări", isReplyGenerator: true,
                 fields: [
-                    { id: 'receivedWish', label: 'Urărea primită:', type: 'textarea', placeholder: 'Introduceți aici textul urării pe care ați primit-o...' },
+                    { id: 'receivedWish', label: 'Urarea primită:', type: 'textarea', placeholder: 'Introduceți aici textul urării pe care ați primit-o...' },
                     { id: 'senderRelationship', label: 'Relația cu expeditorul (opțional):', type: 'text', placeholder: 'Ex: prieten bun, colegă' }
                 ],
                 showGiftButton: false 


### PR DESCRIPTION
## Summary
- fix minor typo in label for reply wishes field

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ffd7682dc8329b31afd149c2f1c1d