### PR TITLE
Improve tab layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,13 +156,14 @@
 
         /* Tab Styles */
         .tabs-container {
-            display: flex;
-            flex-wrap: wrap; 
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 0.5rem;
             margin-bottom: 2rem;
             border-bottom: 2px solid var(--color-surface-border);
         }
         .tab-button {
-            padding: 0.85rem 1.35rem; 
+            padding: 0.85rem 1.35rem;
             cursor: pointer;
             background-color: transparent;
             border: none;
@@ -171,8 +172,10 @@
             font-weight: 600;
             font-size: 0.95rem;
             transition: color 0.3s ease, border-bottom-color 0.3s ease, background-color 0.3s ease;
-            margin-right: 0.25rem; 
-            margin-bottom: -2px; 
+            text-align: center;
+            white-space: nowrap;
+            margin: 0;
+            margin-bottom: -2px;
             border-top-left-radius: var(--border-radius-input);
             border-top-right-radius: var(--border-radius-input);
         }


### PR DESCRIPTION
## Summary
- make tab buttons use responsive grid layout
- prevent long tab labels from wrapping

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684010c657248329ad49047717fdc9b2