### PR TITLE
Adjust tabs grid on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,11 +186,21 @@
         .tab-button.active {
             color: var(--color-accent-celestial-blue);
             border-bottom-color: var(--color-accent-celestial-blue);
-            background-color: rgba(88, 166, 255, 0.1); 
+            background-color: rgba(88, 166, 255, 0.1);
+        }
+
+        @media (max-width: 640px) {
+            .tabs-container {
+                grid-template-columns: repeat(4, 1fr);
+            }
+            .tab-button {
+                font-size: 0.8rem;
+                padding: 0.6rem 0.25rem;
+            }
         }
         .tab-content {
             display: none;
-            padding-top: 2rem; 
+            padding-top: 2rem;
             animation: fadeIn 0.5s ease-in-out;
         }
         .tab-content.active {


### PR DESCRIPTION
## Summary
- tweak `.tabs-container` grid for narrow viewports
- shrink button padding and font size at 640px width

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840347f002883298faa41f029900800