### PR TITLE
Add ARIA labels to wish card buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -685,6 +685,7 @@
             const copyButton = document.createElement('button');
             copyButton.classList.add('btn-copy');
             copyButton.title = "Copiază textul";
+            copyButton.setAttribute('aria-label', copyButton.title);
             copyButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"></path></svg>`;
             copyButton.onclick = (event) => copyWishText(cleanedWish, event.currentTarget);
             
@@ -704,9 +705,12 @@
                 if (isCurrentlyFavorite) heartButton.classList.add('is-favorite');
                 heartButton.innerHTML = getFavoriteIconSVG(isCurrentlyFavorite);
                 heartButton.title = isCurrentlyFavorite ? "Șterge de la favorite" : "Adaugă la favorite";
+                heartButton.setAttribute('aria-label', heartButton.title);
                 heartButton.onclick = () => {
                     toggleFavorite(cleanedWish, uniqueWishId, heartButton);
-                    heartButton.title = favorites.some(fav => fav.id === uniqueWishId) ? "Șterge de la favorite" : "Adaugă la favorite";
+                    const newTitle = favorites.some(fav => fav.id === uniqueWishId) ? "Șterge de la favorite" : "Adaugă la favorite";
+                    heartButton.title = newTitle;
+                    heartButton.setAttribute('aria-label', newTitle);
                 };
                 buttonsWrapper.insertBefore(heartButton, copyButtonContainer); 
             }

--- a/tests/createWishCardDOM.test.js
+++ b/tests/createWishCardDOM.test.js
@@ -18,13 +18,19 @@ describe('createWishCardDOM', () => {
     const el = createWishCardDOM('Happy wishes', 'wish-1', 'u1');
     expect(el).not.toBeNull();
     expect(el.querySelector('p.wish-text').textContent).toBe('Happy wishes');
-    expect(el.querySelector('button.btn-copy')).not.toBeNull();
+    const copyBtn = el.querySelector('button.btn-copy');
+    expect(copyBtn).not.toBeNull();
+    expect(copyBtn.getAttribute('aria-label')).toBe(copyBtn.title);
+    const heartBtn = el.querySelector('button.btn-favorite');
+    expect(heartBtn.getAttribute('aria-label')).toBe(heartBtn.title);
     expect(el.querySelector('button.btn-secondary')).not.toBeNull();
   });
 
   test('returns a DOM element without continue button when includeActions=false', () => {
     const el = createWishCardDOM('Happy', 'wish-2', 'u2', false, false);
-    expect(el.querySelector('button.btn-copy')).not.toBeNull();
+    const copyBtn = el.querySelector('button.btn-copy');
+    expect(copyBtn).not.toBeNull();
+    expect(copyBtn.getAttribute('aria-label')).toBe(copyBtn.title);
     expect(el.querySelector('button.btn-secondary')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- ensure copy/favorite buttons mirror their titles with `aria-label`
- keep aria-label updated when toggling favorites
- verify ARIA labels in unit tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684034a3c37883298e9a7504bf820c2c