### PR TITLE
Add icons, memory and UX improvements

### DIFF
--- a/generator-urari.html
+++ b/generator-urari.html
@@ -33,7 +33,14 @@
             <h1 class="title-font text-4xl sm:text-5xl md:text-6xl mb-3">Generatorul de Urări</h1>
             <p class="subtitle-font text-lg md:text-xl">Creează mesaje personalizate pentru orice ocazie.</p>
         </header>
-            <div class="mb-6 text-center"><a href="index.html" class="text-[#58a6ff] hover:text-[#79c0ff] underline">Acasă</a></div>
+        <div class="mb-6 flex justify-between">
+            <a href="index.html" class="icon-nav-btn" aria-label="Acasă">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path d="M3 9.75L12 3l9 6.75V21a.75.75 0 0 1-.75.75H3.75A.75.75 0 0 1 3 21V9.75z"/><path d="M9 22V12h6v10" stroke="#0d1117" stroke-width="0"/></svg>
+            </a>
+            <a href="index.html" class="icon-nav-btn" aria-label="Înapoi">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path d="M15.75 19.5L8.25 12l7.5-7.5" stroke="#0d1117" stroke-width="0"/></svg>
+            </a>
+        </div>
 
         <div class="tabs-container" id="tabsContainer">
         </div>
@@ -108,7 +115,8 @@
 
         const API_MODEL = "gemini-2.0-flash";
         const FAVORITES_KEY = 'generatorUrariFavorites';
-        let favorites = JSON.parse(localStorage.getItem(FAVORITES_KEY)) || [];
+        let favorites = JSON.parse(sessionStorage.getItem(FAVORITES_KEY)) || JSON.parse(localStorage.getItem(FAVORITES_KEY)) || [];
+        sessionStorage.setItem(FAVORITES_KEY, JSON.stringify(favorites));
 
         const occasions = [
             { 
@@ -355,12 +363,14 @@
                 heartButton.innerHTML = getFavoriteIconSVG(true);
             }
             localStorage.setItem(FAVORITES_KEY, JSON.stringify(favorites));
+            sessionStorage.setItem(FAVORITES_KEY, JSON.stringify(favorites));
             updateFavoritesButtonVisibility();
         }
         
         function removeFavorite(wishId) {
             favorites = favorites.filter(fav => fav.id !== wishId);
             localStorage.setItem(FAVORITES_KEY, JSON.stringify(favorites));
+            sessionStorage.setItem(FAVORITES_KEY, JSON.stringify(favorites));
             updateFavoritesButtonVisibility();
         }
 
@@ -613,12 +623,13 @@
                 let formHTML = '<div class="space-y-6 md:space-y-8">';
                 occasion.fields.forEach(field => {
                     formHTML += `<div><label for="${field.id}-${occasion.id}" class="block label-style">${field.label}</label>`;
+                    formHTML += `<div class="flex items-center gap-2">`;
                     if (field.type === 'textarea') {
-                        formHTML += `<textarea id="${field.id}-${occasion.id}" class="textarea-style" placeholder="${field.placeholder || ''}"></textarea>`;
+                        formHTML += `<textarea id="${field.id}-${occasion.id}" class="textarea-style flex-grow" placeholder="${field.placeholder || ''}"></textarea>`;
                     } else {
-                        formHTML += `<input type="${field.type}" id="${field.id}-${occasion.id}" class="input-style" placeholder="${field.placeholder || ''}">`;
+                        formHTML += `<input type="${field.type}" id="${field.id}-${occasion.id}" class="input-style flex-grow" placeholder="${field.placeholder || ''}">`;
                     }
-                    formHTML += `</div>`;
+                    formHTML += `<button type="button" class="clear-field-btn" aria-label="Șterge">&times;</button></div></div>`;
                 });
 
                 if (occasion.tones) {
@@ -645,7 +656,7 @@
                     });
                 }
                 
-                formHTML += `<div class="main-action-buttons grid grid-cols-1 gap-4 pt-6"> 
+                formHTML += `<div class="pt-2"><button type="button" class="btn-secondary w-full clear-all-fields">Șterge tot</button></div><div class="main-action-buttons grid grid-cols-1 gap-4 pt-6"> 
                                 <button class="btn-primary w-full generate-wish-for-tab-button" data-occasion-id="${occasion.id}">
                                     Generează ${occasion.isReplyGenerator ? 'Răspunsuri' : occasion.promptName}
                                 </button>
@@ -662,6 +673,7 @@
                 formHTML += `</div><div id="wishes-results-container-${occasion.id}" class="mt-12 md:mt-16"></div>`;
                 contentPane.innerHTML = formHTML;
                 tabContentContainer.appendChild(contentPane);
+                restoreTabState(occasion.id);
             });
             
             document.querySelectorAll('.generate-wish-for-tab-button').forEach(button => {
@@ -847,12 +859,13 @@
         function displayWishes(wishesArray, containerElement, title = "Sugestii de Urări:") {
             containerElement.innerHTML = `<h2 class="section-title text-center !text-xl !mb-6">${sanitizeHTML(title)}</h2>`;
             wishesArray.forEach((wish, index) => {
-                const uniqueWishId = `wish-text-${activeTabId}-${Date.now()}-${index}`; 
+                const uniqueWishId = `wish-text-${activeTabId}-${Date.now()}-${index}`;
                 const domWishId = `wish-dom-${activeTabId}-${index}`;
                 const wishElement = createWishCardDOM(wish, domWishId, uniqueWishId);
                 containerElement.appendChild(wishElement);
                 setTimeout(() => wishElement.classList.add('visible'), 10 + index * 120);
             });
+            sessionStorage.setItem(`gu-results-${activeTabId}`, containerElement.innerHTML);
         }
 
         function displayGiftIdeas(ideasArray, introText = "") {
@@ -877,11 +890,52 @@
             });
             giftIdeasResultsContainer.appendChild(listElement);
              giftIdeasResultsContainer.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            sessionStorage.setItem(`gu-gifts-${activeTabId}`, giftIdeasResultsContainer.innerHTML);
+        }
+
+        function restoreTabState(tabId) {
+            const pane = document.getElementById(tabId);
+            if(!pane) return;
+            pane.querySelectorAll('input, textarea, select').forEach(el => {
+                const key = `gu-${tabId}-${el.id}`;
+                const stored = sessionStorage.getItem(key);
+                if(stored !== null) {
+                    if(el.type === 'checkbox') el.checked = stored === 'true';
+                    else el.value = stored;
+                }
+                const handler = () => {
+                    if(el.type === 'checkbox') sessionStorage.setItem(key, el.checked);
+                    else sessionStorage.setItem(key, el.value);
+                };
+                el.addEventListener('input', handler);
+                el.addEventListener('change', handler);
+            });
+            const res = sessionStorage.getItem(`gu-results-${tabId}`);
+            if(res) {
+                const cont = document.getElementById(`wishes-results-container-${tabId}`);
+                if(cont) { cont.innerHTML = res; }
+            }
+            const gifts = sessionStorage.getItem(`gu-gifts-${tabId}`);
+            if(gifts) giftIdeasResultsContainer.innerHTML = gifts;
+            pane.querySelectorAll('.clear-field-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const input = btn.parentElement.querySelector('input, textarea');
+                    if(input){ input.value=''; input.dispatchEvent(new Event('input')); }
+                });
+            });
+            const clearAll = pane.querySelector('.clear-all-fields');
+            if(clearAll) clearAll.addEventListener('click', () => {
+                pane.querySelectorAll('input, textarea').forEach(el => {
+                    el.value='';
+                    el.dispatchEvent(new Event('input'));
+                });
+            });
         }
         // --- Initialize Tabs ---
-        createTabs(); 
+        createTabs();
         if (occasions.length > 0) {
-            switchTab(occasions[0].id); 
+            switchTab(occasions[0].id);
+            restoreTabState(occasions[0].id);
         }
         updateFavoritesButtonVisibility();
 

--- a/idei-cadou.html
+++ b/idei-cadou.html
@@ -21,28 +21,51 @@
     <main class="flex-grow w-full px-4 flex items-start justify-center">
         <div class="generator-container w-full max-w-2xl">
             <h1 class="text-3xl sm:text-4xl font-bold text-[#58a6ff] mb-8 text-center">Generare idei de cadouri</h1>
-            <div class="mb-6 text-center"><a href="index.html" class="text-[#58a6ff] hover:text-[#79c0ff] underline">Acasă</a></div>
+            <div class="mb-6 flex justify-between">
+                <a href="index.html" class="icon-nav-btn" aria-label="Acasă">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path d="M3 9.75L12 3l9 6.75V21a.75.75 0 0 1-.75.75H3.75A.75.75 0 0 1 3 21V9.75z"/><path d="M9 22V12h6v10" stroke="#0d1117" stroke-width="0"/></svg>
+                </a>
+                <a href="index.html" class="icon-nav-btn" aria-label="Înapoi">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path d="M15.75 19.5L8.25 12l7.5-7.5" stroke="#0d1117" stroke-width="0"/></svg>
+                </a>
+            </div>
             <form id="gift-form" class="space-y-4">
                 <div>
                     <label class="label-style" for="dest">Nume destinatar (opțional)</label>
-                    <input id="dest" type="text" class="input-style" placeholder="Ex: Ana" />
+                    <div class="flex items-center gap-2">
+                        <input id="dest" type="text" class="input-style flex-grow" placeholder="Ex: Ana" />
+                        <button type="button" class="clear-field-btn" aria-label="Șterge">&times;</button>
+                    </div>
                 </div>
                 <div>
                     <label class="label-style" for="age">Vârsta</label>
-                    <input id="age" type="number" class="input-style" placeholder="30" />
+                    <div class="flex items-center gap-2">
+                        <input id="age" type="number" class="input-style flex-grow" placeholder="30" />
+                        <button type="button" class="clear-field-btn" aria-label="Șterge">&times;</button>
+                    </div>
                 </div>
                 <div>
                     <label class="label-style" for="rel">Relația cu tine</label>
-                    <input id="rel" type="text" class="input-style" placeholder="Ex: colegă" />
+                    <div class="flex items-center gap-2">
+                        <input id="rel" type="text" class="input-style flex-grow" placeholder="Ex: colegă" />
+                        <button type="button" class="clear-field-btn" aria-label="Șterge">&times;</button>
+                    </div>
                 </div>
                 <div>
                     <label class="label-style" for="occ">Ocazia</label>
-                    <input id="occ" type="text" class="input-style" placeholder="Zi de naștere" />
+                    <div class="flex items-center gap-2">
+                        <input id="occ" type="text" class="input-style flex-grow" placeholder="Zi de naștere" />
+                        <button type="button" class="clear-field-btn" aria-label="Șterge">&times;</button>
+                    </div>
                 </div>
                 <div>
                     <label class="label-style" for="hobby">Interese și hobby-uri (opțional)</label>
-                    <input id="hobby" type="text" class="input-style" placeholder="Fotografie, lectură" />
+                    <div class="flex items-center gap-2">
+                        <input id="hobby" type="text" class="input-style flex-grow" placeholder="Fotografie, lectură" />
+                        <button type="button" class="clear-field-btn" aria-label="Șterge">&times;</button>
+                    </div>
                 </div>
+                <div><button type="button" id="clear-form" class="btn-secondary w-full">Șterge tot</button></div>
                 <button type="button" id="gen-btn" class="btn-primary w-full">Generează idei de cadou</button>
             </form>
             <div id="gift-results" class="mt-8 hidden">
@@ -66,6 +89,31 @@
         const genBtn = document.getElementById('gen-btn');
         const resultsContainer = document.getElementById('gift-results');
         const errorContainer = document.getElementById('error-message-container');
+        const fieldsIds = ['dest','age','rel','occ','hobby'];
+        fieldsIds.forEach(id => {
+            const el = document.getElementById(id);
+            const stored = sessionStorage.getItem(`gift-${id}`);
+            if(stored !== null) el.value = stored;
+            el.addEventListener('input', () => sessionStorage.setItem(`gift-${id}`, el.value));
+        });
+        const storedRes = sessionStorage.getItem('gift-results');
+        if(storedRes) { resultsContainer.innerHTML = storedRes; resultsContainer.classList.remove('hidden'); }
+        document.querySelectorAll('.clear-field-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const input = btn.parentElement.querySelector('input');
+                if(input){ input.value=''; input.dispatchEvent(new Event('input')); }
+            });
+        });
+        const clearFormBtn = document.getElementById('clear-form');
+        if(clearFormBtn) clearFormBtn.addEventListener('click', () => {
+            fieldsIds.forEach(id => {
+                const el = document.getElementById(id);
+                if(el){ el.value=''; el.dispatchEvent(new Event('input')); }
+            });
+            resultsContainer.innerHTML='';
+            resultsContainer.classList.add('hidden');
+            sessionStorage.removeItem('gift-results');
+        });
 
         function displayError(message) {
             errorContainer.innerHTML = '';
@@ -101,6 +149,7 @@
             resultsContainer.appendChild(listEl);
             resultsContainer.classList.remove('hidden');
             resultsContainer.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            sessionStorage.setItem('gift-results', resultsContainer.innerHTML);
         }
 
         async function callGeminiAPI(promptText, button, originalHTML) {

--- a/index.html
+++ b/index.html
@@ -20,10 +20,16 @@
     </div>
     <main class="flex-grow flex items-center justify-center w-full px-4">
         <div class="generator-container w-full max-w-2xl text-center">
-            <h1 class="text-3xl sm:text-4xl md:text-5xl font-bold text-[#58a6ff] mb-8">Cu ce te putem ajuta azi?</h1>
+            <h1 class="title-font text-4xl sm:text-5xl md:text-6xl mb-8">Cu ce te putem ajuta azi?</h1>
             <div class="flex flex-col sm:flex-row gap-4">
-                <a href="/generator-urari.html" class="animate-pulse-slow bg-[#21262d] hover:bg-[#30363d] text-[#c9d1d9] rounded-xl shadow px-6 py-4 text-lg font-semibold w-full sm:w-1/2">Generatorul de urări</a>
-                <a href="/idei-cadou.html" class="animate-pulse-slow bg-[#21262d] hover:bg-[#30363d] text-[#c9d1d9] rounded-xl shadow px-6 py-4 text-lg font-semibold w-full sm:w-1/2">Idei de cadouri</a>
+                <a href="/generator-urari.html" class="animate-pulse-slow bg-[#21262d] hover:bg-[#30363d] text-[#c9d1d9] rounded-xl shadow flex flex-col justify-center items-center aspect-square text-lg font-semibold w-full sm:w-1/2">
+                    Generatorul de urări
+                    <span class="text-5xl mt-2">🗣️</span>
+                </a>
+                <a href="/idei-cadou.html" class="animate-pulse-slow bg-[#21262d] hover:bg-[#30363d] text-[#c9d1d9] rounded-xl shadow flex flex-col justify-center items-center aspect-square text-lg font-semibold w-full sm:w-1/2">
+                    Idei de cadouri
+                    <span class="text-5xl mt-2">🎁</span>
+                </a>
             </div>
         </div>
     </main>

--- a/style.css
+++ b/style.css
@@ -308,3 +308,34 @@
         @media (max-width: 1024px) {
             .ad-sidebar { display: none; }
         }
+.clear-field-btn {
+    border: 1px solid var(--color-surface-border);
+    background-color: transparent;
+    color: var(--color-text-secondary);
+    border-radius: 9999px;
+    width: 1.75rem;
+    height: 1.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+.clear-field-btn:hover {
+    background-color: rgba(88,166,255,0.1);
+    color: var(--color-text-primary);
+}
+.icon-nav-btn {
+    border: 1px solid var(--color-surface-border);
+    border-radius: 0.5rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-accent-celestial-blue);
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+.icon-nav-btn:hover {
+    background-color: rgba(88,166,255,0.1);
+    color: var(--color-accent-celestial-blue-hover);
+}


### PR DESCRIPTION
## Summary
- replace text home link with icon-based navigation
- add back button and clear field features on form pages
- remember generated results and inputs in session storage
- tweak home page buttons and header style
- provide clear input buttons and CSS helper classes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840afea76fc832980a238b4cb892974