### PR TITLE
Fix mobile layout for homepage buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <main class="flex-grow flex items-center justify-center w-full px-4">
         <div class="generator-container w-full max-w-2xl text-center">
             <h1 class="title-font text-4xl sm:text-5xl md:text-6xl mb-8">Cu ce te putem ajuta azi?</h1>
-            <div class="flex flex-row gap-x-6 justify-center overflow-x-auto">
+            <div class="flex flex-col sm:flex-row gap-4 sm:gap-6 items-center justify-center">
                 <a href="/generator-urari.html" class="animate-pulse-slow bg-[#21262d] hover:bg-[#30363d] text-[#c9d1d9] rounded-xl shadow flex flex-col justify-center items-center aspect-square text-lg font-semibold flex-none w-[170px] p-4">
                     Generatorul de urări
                     <span class="text-5xl mt-2">🗣️</span>


### PR DESCRIPTION
## Summary
- keep homepage buttons side by side on desktop
- stack homepage buttons vertically on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b8ffeaa48329916c7496e543c4b0