### PR TITLE
Fix button glow clipping and adjust mobile width

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,11 @@
         <div class="generator-container w-full max-w-2xl text-center">
             <h1 class="title-font text-4xl sm:text-5xl md:text-6xl mb-8">Cu ce te putem ajuta azi?</h1>
             <div class="flex flex-row gap-x-6 justify-center overflow-x-auto">
-                <a href="/generator-urari.html" class="animate-pulse-slow btn-primary rounded-xl shadow flex flex-col justify-center items-center aspect-square text-lg font-semibold flex-none w-[170px] p-4">
+                <a href="/generator-urari.html" class="animate-pulse-slow btn-primary rounded-xl shadow flex flex-col justify-center items-center aspect-square text-lg font-semibold flex-none w-[90%] sm:w-[170px] p-4">
                     Generatorul de urări
                     <span class="text-5xl mt-2">🗣️</span>
                 </a>
-                <a href="/idei-cadou.html" class="animate-pulse-slow btn-primary-reverse rounded-xl shadow flex flex-col justify-center items-center aspect-square text-lg font-semibold flex-none w-[170px] p-4">
+                <a href="/idei-cadou.html" class="animate-pulse-slow btn-primary-reverse rounded-xl shadow flex flex-col justify-center items-center aspect-square text-lg font-semibold flex-none w-[90%] sm:w-[170px] p-4">
                     Idei de cadouri
                     <span class="text-5xl mt-2">🎁</span>
                 </a>

--- a/style.css
+++ b/style.css
@@ -69,7 +69,7 @@
             padding: 1.5rem; 
             position: relative;
             z-index: 1; 
-            overflow: hidden; 
+            overflow: visible;
         }
         @media (min-width: 768px) { .generator-container { padding: 2rem; } }
         .generator-container::before { content: ''; position: absolute; top: 0; left: 0; right: 0; bottom: 0; border-radius: inherit; padding: 1px; background: linear-gradient(120deg, transparent, var(--color-accent-celestial-blue), transparent, var(--color-accent-magenta-flare), transparent); background-size: 300% 300%; animation: borderGlow 10s linear infinite; -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0); -webkit-mask-composite: destination-out; mask-composite: exclude; z-index: -1; }


### PR DESCRIPTION
## Summary
- let homepage buttons overflow generator container so glow isn't cut off
- expand homepage buttons' width on mobile

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c0a3667883299da9e29094e57cea