### PR TITLE
Add backend endpoint for Gemini API

### DIFF
--- a/generator-urari.html
+++ b/generator-urari.html
@@ -115,6 +115,7 @@
         document.getElementById('currentYear').textContent = new Date().getFullYear();
 
         const API_MODEL = "gemini-2.0-flash";
+        const API_ENDPOINT = "/api/generate";
         const FAVORITES_KEY = 'generatorUrariFavorites';
         let favorites = JSON.parse(sessionStorage.getItem(FAVORITES_KEY)) || JSON.parse(localStorage.getItem(FAVORITES_KEY)) || [];
         sessionStorage.setItem(FAVORITES_KEY, JSON.stringify(favorites));
@@ -399,32 +400,22 @@
             errorMessageContainer.classList.add('hidden');
 
             try {
-                let chatHistory = [{ role: "user", parts: [{ text: promptText }] }];
-                const payload = { contents: chatHistory };
-                const apiKey = "";
-                if (!apiKey) {
-                    displayError('Cheia API lipsește. Configurează cheia înainte de a folosi generatorul.');
-                    return null;
-                }
-                const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${API_MODEL}:generateContent?key=${apiKey}`;
-                const response = await fetch(apiUrl, {
+                const response = await fetch(API_ENDPOINT, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(payload)
+                    body: JSON.stringify({ prompt: promptText })
                 });
                 if (!response.ok) {
                     const errorData = await response.json().catch(() => ({ error: { message: "Răspuns invalid de la server." } }));
                     throw new Error(`Serviciul de generare a întâmpinat o problemă: ${errorData.error?.message || response.statusText} (Cod: ${response.status})`);
                 }
                 const result = await response.json();
-                if (result.candidates && result.candidates.length > 0 &&
-                    result.candidates[0].content && result.candidates[0].content.parts &&
-                    result.candidates[0].content.parts.length > 0) {
-                    let text = result.candidates[0].content.parts[0].text;
-                    text = text.replace(/\([\s\S]*?\)/g, '').replace(/\[[\s\S]*?\]/g, ''); 
+                if (result.text) {
+                    let text = result.text;
+                    text = text.replace(/\([\s\S]*?\)/g, '').replace(/\[[\s\S]*?\]/g, '');
                     return text.trim();
                 } else {
-                    throw new Error("Am primit un răspuns neașteptat de la serviciul de generare.");
+                    throw new Error("Am primit un răspuns neașteptat de la serviciu.");
                 }
             } catch (error) {
                 console.error('Eroare la apelul API Gemini:', error);

--- a/package.json
+++ b/package.json
@@ -6,13 +6,17 @@
   "scripts": {
     "test": "jest"
   },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^30.0.0-beta.3",
+    "jest-environment-jsdom": "^29.7.0",
     "jsdom": "^26.1.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,41 @@
+require('dotenv').config();
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3000;
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const API_MODEL = 'gemini-2.0-flash';
+app.use(express.json());
+
+app.post('/api/generate', async (req, res) => {
+  if (!GEMINI_API_KEY) {
+    return res.status(500).json({ error: 'API key not configured' });
+  }
+  const { prompt } = req.body;
+  if (!prompt) {
+    return res.status(400).json({ error: 'Missing prompt' });
+  }
+  try {
+    const payload = { contents: [{ role: 'user', parts: [{ text: prompt }] }] };
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${API_MODEL}:generateContent?key=${GEMINI_API_KEY}`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      return res.status(response.status).json({ error: data.error?.message || 'Failed to call Gemini' });
+    }
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+    res.json({ text });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to call Gemini API' });
+  }
+});
+
+if (require.main === module) {
+  app.listen(PORT, () => console.log(`Server listening on port ${PORT}`));
+}
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- implement simple Express server that calls Gemini API using `GEMINI_API_KEY`
- add dependencies for `express` and `dotenv`
- update front-end generator to post prompts to new backend endpoint
- align Jest environment packages

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841d7960488832984f23df118e4c004