### PR TITLE
Update theme toggle icons

### DIFF
--- a/confidentialitate.html
+++ b/confidentialitate.html
@@ -9,7 +9,7 @@
 </head>
 <body style="background-color: var(--color-background-deep-space); color: var(--color-text-primary);">
     <button id="theme-toggle" class="icon-nav-btn fixed top-4 right-4" aria-label="Comută tema">
-        <img id="theme-icon" src="icons/moon-dark.svg" alt="Icon lună" />
+        <img id="theme-icon" src="icons/light-button.svg" alt="Icon soare" />
     </button>
     <div class="max-w-3xl mx-auto p-8">
         <h1 class="text-[#58a6ff] text-3xl font-bold mb-6 text-center">Politica de Confidențialitate</h1>

--- a/generator-urari.html
+++ b/generator-urari.html
@@ -41,7 +41,7 @@
                 <img id="back-icon" src="icons/back-dark.svg" alt="Înapoi" />
             </a>
             <button id="theme-toggle" class="icon-nav-btn" aria-label="Comută tema">
-                <img id="theme-icon" src="icons/moon-dark.svg" alt="Icon lună" />
+                <img id="theme-icon" src="icons/light-button.svg" alt="Icon soare" />
             </button>
         </div>
 

--- a/idei-cadou.html
+++ b/idei-cadou.html
@@ -29,7 +29,7 @@
                     <img id="back-icon" src="icons/back-dark.svg" alt="Înapoi" />
                 </a>
                 <button id="theme-toggle" class="icon-nav-btn" aria-label="Comută tema">
-                    <img id="theme-icon" src="icons/moon-dark.svg" alt="Icon lună" />
+                    <img id="theme-icon" src="icons/light-button.svg" alt="Icon soare" />
                 </button>
             </div>
             <form id="gift-form" class="space-y-4">

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 </head>
 <body class="flex flex-col items-center min-h-screen selection:bg-blue-100 selection:text-blue-700">
     <button id="theme-toggle" class="icon-nav-btn fixed top-4 right-4" aria-label="Comută tema">
-        <img id="theme-icon" src="icons/moon-dark.svg" alt="Icon lună" />
+        <img id="theme-icon" src="icons/light-button.svg" alt="Icon soare" />
     </button>
     <div class="dust-motes-container pointer-events-none absolute inset-0 overflow-hidden -z-10">
         <span class="dust-mote mote1"></span>

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -9,7 +9,7 @@
 </head>
 <body style="background-color: var(--color-background-deep-space); color: var(--color-text-primary);">
     <button id="theme-toggle" class="icon-nav-btn fixed top-4 right-4" aria-label="Comută tema">
-        <img id="theme-icon" src="icons/moon-dark.svg" alt="Icon lună" />
+        <img id="theme-icon" src="icons/light-button.svg" alt="Icon soare" />
     </button>
     <div class="max-w-3xl mx-auto p-8">
         <h1 class="text-[#58a6ff] text-3xl font-bold mb-6 text-center">Politica de Cookies</h1>

--- a/theme-toggle.js
+++ b/theme-toggle.js
@@ -4,12 +4,12 @@
   const btnId = 'theme-toggle';
   const icons = {
     light: {
-      theme: 'icons/sun-light.svg',
+      theme: 'icons/dark-button.svg',
       home: 'icons/home-light.svg',
       back: 'icons/back-light.svg'
     },
     dark: {
-      theme: 'icons/moon-dark.svg',
+      theme: 'icons/light-button.svg',
       home: 'icons/home-dark.svg',
       back: 'icons/back-dark.svg'
     }
@@ -27,7 +27,11 @@
 
   function updateIcons(isLight) {
     const variant = isLight ? 'light' : 'dark';
-    swapIcon(document.querySelector('#theme-icon'), icons[variant].theme, isLight ? 'Icon soare' : 'Icon lună');
+    swapIcon(
+      document.querySelector('#theme-icon'),
+      icons[variant].theme,
+      isLight ? 'Icon lună' : 'Icon soare'
+    );
     swapIcon(document.querySelector('#home-icon'), icons[variant].home, 'Acasă');
     swapIcon(document.querySelector('#back-icon'), icons[variant].back, 'Înapoi');
   }


### PR DESCRIPTION
## Summary
- update `theme-toggle.js` to show `dark-button.svg` when light theme is active and `light-button.svg` when dark theme is active
- switch initial icon references across html files

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684219e0c2588329b473c45f1bdd2c57