### PR TITLE
Add main tags to info pages

### DIFF
--- a/confidentialitate.html
+++ b/confidentialitate.html
@@ -11,6 +11,7 @@
     <button id="theme-toggle" class="icon-nav-btn fixed top-4 right-4" aria-label="Comută tema">
         <img id="theme-icon" src="icons/light-button.svg" alt="Icon soare" />
     </button>
+    <main>
     <div class="max-w-3xl mx-auto p-8">
         <h1 class="text-[#58a6ff] text-3xl font-bold mb-6 text-center">Politica de Confidențialitate</h1>
 
@@ -47,6 +48,8 @@
             <h2 class="text-xl font-semibold mb-2">Contact</h2>
             <p class="mb-4">Nu colectăm date de identificare, dar ne poți scrie la <a href="mailto:contact@generatorulmeu.com" class="underline text-[#58a6ff] hover:text-[#79c0ff]">contact@generatorulmeu.com</a> dacă ai întrrebări.</p>
         </section>
+    </div>
+    </main>
 
         <footer class="text-center text-gray-500">
             <p>Ultima actualizare: Iunie 2025</p>
@@ -55,7 +58,6 @@
                 <a href="/confidentialitate.html" class="text-[#58a6ff] hover:text-[#79c0ff] underline">Politica de Confidențialitate</a>
             </p>
         </footer>
-    </div>
 
     <div id="cookie-banner" class="hidden fixed bottom-0 inset-x-0 bg-[#161b22] text-white p-4 shadow flex flex-col md:flex-row items-center justify-between space-y-2 md:space-y-0">
         <span>Folosim cookies pentru a îmbunătăți experiența ta și pentru viitoare reclame. Continuarea navigării implică acceptul tău.</span>

--- a/generator-urari.html
+++ b/generator-urari.html
@@ -28,7 +28,8 @@
         <span class="dust-mote mote6"></span>
     </div>
 
-    <div class="generator-container w-full max-w-4xl"> 
+    <main>
+    <div class="generator-container w-full max-w-4xl">
         <header class="text-center mb-10 md:mb-12"> 
             <h1 class="title-font text-4xl sm:text-5xl md:text-6xl mb-3">Generatorul de Urări</h1>
             <p class="subtitle-font text-lg md:text-xl">Creează mesaje personalizate pentru orice ocazie.</p>
@@ -84,6 +85,7 @@
             </div>
         </div>
     </div>
+    </main>
 
     <footer class="text-center p-8 mt-16 text-sm text-gray-500">
         <p>&copy; <span id="currentYear"></span> Generator de Urări Autentice. Creat cu inspirație.</p>

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -11,6 +11,7 @@
     <button id="theme-toggle" class="icon-nav-btn fixed top-4 right-4" aria-label="Comută tema">
         <img id="theme-icon" src="icons/light-button.svg" alt="Icon soare" />
     </button>
+    <main>
     <div class="max-w-3xl mx-auto p-8">
         <h1 class="text-[#58a6ff] text-3xl font-bold mb-6 text-center">Politica de Cookies</h1>
 
@@ -42,6 +43,8 @@
             <h2 class="text-xl font-semibold mb-2">Cum le poți controla</h2>
             <p class="mb-4">Poți bloca sau șterge cookies din setările browserului. Reține însă că unele funcționalități ale site-ului pot fi afectate dacă dezactivezi cookies. Pentru a șterge cookies, accesează meniul de setări al browserului și alege opțiunea de ștergere a datelor de navigare.</p>
         </section>
+    </div>
+    </main>
 
         <footer class="text-center text-gray-500">
             <p>Ultima actualizare: Iunie 2025</p>
@@ -50,7 +53,6 @@
                 <a href="/confidentialitate.html" class="text-[#58a6ff] hover:text-[#79c0ff] underline">Politica de Confidențialitate</a>
             </p>
         </footer>
-    </div>
 
     <div id="cookie-banner" class="hidden fixed bottom-0 inset-x-0 bg-[#161b22] text-white p-4 shadow flex flex-col md:flex-row items-center justify-between space-y-2 md:space-y-0">
         <span>Folosim cookies pentru a îmbunătăți experiența ta și pentru viitoare reclame. Continuarea navigării implică acceptul tău.</span>


### PR DESCRIPTION
## Summary
- wrap main content in `<main>` tags for better semantics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68421bc4e3608329b88b30d4881a8339