### PR TITLE
Update styling for generator and gift pages

### DIFF
--- a/generator-urari.html
+++ b/generator-urari.html
@@ -29,7 +29,7 @@
         <span class="dust-mote mote6"></span>
     </div>
 
-    <div class="generator-container w-full max-w-4xl"> 
+    <div class="generator-container w-full max-w-2xl">
         <header class="text-center mb-10 md:mb-12"> 
             <h1 class="title-font text-4xl sm:text-5xl md:text-6xl mb-3">Generatorul de Urări</h1>
             <p class="subtitle-font text-lg md:text-xl">Creează mesaje personalizate pentru orice ocazie.</p>

--- a/idei-cadou.html
+++ b/idei-cadou.html
@@ -21,7 +21,7 @@
     </div>
     <main class="flex-grow w-full px-4 flex items-start justify-center">
         <div class="generator-container w-full max-w-2xl">
-            <h1 class="text-3xl sm:text-4xl font-bold text-[#58a6ff] mb-8 text-center">Generare idei de cadouri</h1>
+            <h1 class="title-font text-4xl sm:text-5xl md:text-6xl mb-8 text-center">Generare idei de cadouri</h1>
             <div class="mb-6 flex justify-between items-center gap-4">
                 <a href="index.html" class="icon-nav-btn" aria-label="Acasă">
                     <img id="home-icon" src="icons/home-dark.svg" alt="Acasă" />

--- a/parallax-stars.js
+++ b/parallax-stars.js
@@ -38,7 +38,8 @@
 
   function draw() {
     ctx.clearRect(0, 0, width, height);
-    ctx.fillStyle = '#ffffff';
+    ctx.fillStyle = getComputedStyle(document.documentElement)
+      .getPropertyValue('--star-color').trim() || '#ffffff';
     for (const s of stars) {
       s.y += s.speed;
       if (s.y - s.r > height) {

--- a/style.css
+++ b/style.css
@@ -40,6 +40,7 @@
             --color-surface-glass: rgba(255, 255, 255, 0.8);
             --color-surface-border: rgba(0, 0, 0, 0.1);
             --color-surface-glow: rgba(88, 166, 255, 0.3);
+            --star-color: #ffffff;
             --color-text-primary: #1f2937;
             --color-text-secondary: #4b5563;
             --color-text-placeholder: #6b7280;
@@ -60,18 +61,17 @@
             --color-input-bg: rgba(255, 255, 255, 0.9);
             --color-input-bg-focus: rgba(255, 255, 255, 1);
             --color-list-item-bg: rgba(255, 255, 255, 0.7);
+            --star-color: #a3a3a3;
         }
 
         @keyframes backgroundStars { 0% { background-position: 0 0; } 100% { background-position: -10000px 5000px; } }
         
         body {
             font-family: var(--font-primary);
-            background-color: var(--color-background-deep-space);
-            background-image: 
-                url("data:image/svg+xml,%3Csvg width='100' height='100' xmlns='http://www.w3.org/2000/svg'%3E%3Cdefs%3E%3Cfilter id='stars'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='1' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0, 0 0 0 0 0, 0 0 0 0 0, 0 0 0 -0.3 1'/%3E%3C/filter%3E%3C/defs%3E%3Crect width='100%25' height='100%25' filter='url(%23stars)' opacity='0.3'/%3E%3C/svg%3E"),
-                linear-gradient(170deg, var(--color-background-nebula-start) 0%, var(--color-background-nebula-end) 100%);
-            background-size: auto, 200% 200%;
-            animation: gradientFlow 45s ease infinite, backgroundStars 300s linear infinite;
+            background-color: #0b1d3c;
+            background-image: url("data:image/svg+xml,%3Csvg width='100' height='100' xmlns='http://www.w3.org/2000/svg'%3E%3Cdefs%3E%3Cfilter id='stars'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='1' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0, 0 0 0 0 0, 0 0 0 0 0, 0 0 0 -0.3 1'/%3E%3C/filter%3E%3C/defs%3E%3Crect width='100%25' height='100%25' filter='url(%23stars)' opacity='0.3'/%3E%3C/svg%3E");
+            background-size: auto;
+            animation: backgroundStars 300s linear infinite;
             color: var(--color-text-primary);
             line-height: 1.7; 
             padding-top: 2rem; 
@@ -80,7 +80,6 @@
             position: relative; 
             overflow-x: hidden; 
         }
-        @keyframes gradientFlow { 0% { background-position: 0% 50%, 0% 50%; } 50% { background-position: 0% 50%, 100% 50%; } 100% { background-position: 0% 50%, 0% 50%; } }
 
         .dust-motes-container { display: none; }
         #star-canvas { position: fixed; inset: 0; width: 100%; height: 100%; pointer-events: none; z-index: -1; }


### PR DESCRIPTION
## Summary
- drop animated gradient for a solid dark-blue background
- add star color variables and adjust parallax stars
- unify generator container width
- match gift page header style with homepage

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684225a78a7c832994e5ca56f8faec4c